### PR TITLE
Add devcontainer configuration for frontend development

### DIFF
--- a/.devcontainer/.devcontainer.json
+++ b/.devcontainer/.devcontainer.json
@@ -1,0 +1,17 @@
+{
+  "name": "Frontend Dev",
+  "dockerComposeFile": ["../docker-compose.yml"],
+  "service": "frontend",
+  "workspaceFolder": "/app",
+  "features": {
+    "ghcr.io/devcontainers/features/git:1": {}
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
add devcontainer.json for container development by vscode

because current settings can not to sync `node_modules` to own local environment.

solution1: this PR. develop in docker container😉
solution2: npm install in own local machine.
solution3: sync to own local machine.(need to fix docker-compose.yml) but our machine will be slowly.